### PR TITLE
ignore file extension in regexp

### DIFF
--- a/zkviz/zkviz.py
+++ b/zkviz/zkviz.py
@@ -16,7 +16,7 @@ import plotly
 import plotly.graph_objs as go
 
 
-PAT_ZK_ID = re.compile(r'^(?P<id>\d+)\s(.*)\.md')
+PAT_ZK_ID = re.compile(r'^(?P<id>\d+)\s(.*)\.[^\.]+$')
 PAT_LINK = re.compile(r'\[\[(\d+)\]\]')
 
 

--- a/zkviz/zkviz.py
+++ b/zkviz/zkviz.py
@@ -16,7 +16,7 @@ import plotly
 import plotly.graph_objs as go
 
 
-PAT_ZK_ID = re.compile(r'^(?P<id>\d+)\s(.*)\.[^\.]+$')
+PAT_ZK_ID = re.compile(r'^(?P<id>\d+)\s(.*)\.(?!=\.).*$')
 PAT_LINK = re.compile(r'\[\[(\d+)\]\]')
 
 


### PR DESCRIPTION
Since the incoming list of file names already went through the `*.md` or `*.txt` glob or is a manual selection, we can safely ignore what the extension is. I adjusted the regexp to include everything up to the last `.` as the title.

`201906190735 asdf.test.md` will become the groups `['201906190735 asdf.test.md', '201906190735', 'asdf.test']`