### PR TITLE
ENH: Allow different, and multiple file patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ the default with the `--pattern` option:
 ~/envs/zkviz/bin/zkviz --pattern '*.mkdown'
 ```
 
+You can also specify multiple patterns separately. With the following, zkviz
+will find all txt and md files. I recommend wrapping the pattern in quotes.
+
+```sh
+~/envs/zkviz/bin/zkviz --pattern '*.md' --pattern '*.txt'
+```
 You can also pass a list of files to zkviz:
 
 ```sh

--- a/tests/test_zkviz.py
+++ b/tests/test_zkviz.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from zkviz import zkviz
+
+
+class TestListZettels(TestCase):
+
+    def test_list_zettels_with_md_extension(self):
+        # Create a temporary folder and write files in it
+        with TemporaryDirectory() as tmpdirname:
+            ext = '.md'
+            basename = '201906242157'
+            filepaths = []
+            for i in range(3):
+                path = Path(tmpdirname, basename + str(i) + ext)
+                path.touch()
+                filepaths.append(str(path))
+
+            files_found = zkviz.list_zettels(tmpdirname)
+            self.assertEqual(filepaths, files_found)
+
+    def test_list_zettels_with_txt_extension(self):
+        # Create a temporary folder and write files in it
+        with TemporaryDirectory() as tmpdirname:
+            ext = '.txt'
+            basename = '201906242157'
+            filepaths = []
+            for i in range(3):
+                path = Path(tmpdirname, basename + str(i) + ext)
+                path.touch()
+                filepaths.append(str(path))
+
+            files_found = zkviz.list_zettels(tmpdirname, '*.txt')
+            self.assertEqual(filepaths, files_found)
+
+    def test_list_zettels_with_mixed_extensions(self):
+        # Create a temporary folder and write files in it
+        with TemporaryDirectory() as tmpdirname:
+            filepaths = []
+            basename = '201906242157'
+
+            ext = '.txt'
+            for i in range(5):
+                path = Path(tmpdirname, basename + str(i) + ext)
+                path.touch()
+                filepaths.append(str(path))
+
+            ext = '.md'
+            for i in range(5, 10):
+                path = Path(tmpdirname, basename + str(i) + ext)
+                path.touch()
+                filepaths.append(str(path))
+
+            files_found = zkviz.list_zettels(tmpdirname, '*.txt|*.md')
+            self.assertEqual(filepaths, files_found)
+
+
+class TestParseArgs(TestCase):
+
+    def test_default_extension(self):
+        args = zkviz.parse_args('')
+        self.assertEqual(['*.md'], args.pattern)
+
+    def test_overwrite_extension(self):
+        args = zkviz.parse_args(["--pattern","*.txt"])
+        self.assertEqual(['*.txt'], args.pattern)
+
+    def test_multiple_extensions(self):
+        args = zkviz.parse_args(["--pattern","*.txt", "--pattern", '*.md'])
+        self.assertEqual(['*.txt', '*.md'], args.pattern)

--- a/zkviz/zkviz.py
+++ b/zkviz/zkviz.py
@@ -183,7 +183,8 @@ def parse_args(args=None):
     parser.add_argument('--output', default='zettel-network.html',
                         help='name of output file. [zettel-network.html]')
     parser.add_argument('--pattern', action='append',
-            help='pattern to match notes. [*.md]')
+            help=('pattern to match notes. You can repeat this argument to'
+            ' match multiple file types. [*.md]'))
     parser.add_argument('zettel_paths', nargs='*', help='zettel file paths.')
     args = parser.parse_args(args=args)
 

--- a/zkviz/zkviz.py
+++ b/zkviz/zkviz.py
@@ -16,7 +16,7 @@ import plotly
 import plotly.graph_objs as go
 
 
-PAT_ZK_ID = re.compile(r'^(?P<id>\d+)\s(.*)\.md')
+PAT_ZK_ID = re.compile(r'^(?P<id>\d+)\s(.*)')
 PAT_LINK = re.compile(r'\[\[(\d+)\]\]')
 
 
@@ -28,7 +28,8 @@ def parse_zettels(filepaths):
     """
     documents = []
     for filepath in filepaths:
-        filename = os.path.basename(filepath)
+        basename = os.path.basename(filepath)
+        filename, ext = os.path.splitext(basename)
         r = PAT_ZK_ID.match(filename)
         if not r:
             continue

--- a/zkviz/zkviz.py
+++ b/zkviz/zkviz.py
@@ -73,12 +73,16 @@ def list_zettels(notes_dir, pattern='*.md'):
     notes_dir : str
         Path to the directory containing the zettels.
     pattern : str (optional)
-        Pattern matching zettels. The default is '*.md'.
+        Pattern matching zettels. The default is '*.md'. If there are multiple
+        patterns, separate them with a |, such as in '*.md|*.txt'
 
     """
 
-    filepaths = glob.glob(os.path.join(notes_dir, pattern))
-    return filepaths
+    filepaths = []
+
+    for patt in pattern.split('|'):
+        filepaths.extend(glob.glob(os.path.join(notes_dir, patt)))
+    return sorted(filepaths)
 
 
 def create_plotly_plot(graph, pos=None):
@@ -170,28 +174,34 @@ def create_plotly_plot(graph, pos=None):
     return fig
 
 
-def main(args=None):
+def parse_args(args=None):
     from argparse import ArgumentParser
-    import sys
-
     parser = ArgumentParser(description=__doc__)
     parser.add_argument('--notes-dir', default='.',
                         help='path to folder containin notes. [.]')
     parser.add_argument('--output', default='zettel-network.html',
                         help='name of output file. [zettel-network.html]')
-    parser.add_argument('--pattern', default='*.md',
-                        help='pattern to match notes. [*.md]')
+    parser.add_argument('--pattern', action='append',
+            help='pattern to match notes. [*.md]')
     parser.add_argument('zettel_paths', nargs='*', help='zettel file paths.')
     args = parser.parse_args(args=args)
 
     # Use the list of files the user specify, otherwise, fall back to
     # listing a directory.
-    if args.zettel_paths:
-        zettel_paths = args.zettel_paths
-    else:
-        zettel_paths = list_zettels(args.notes_dir, pattern=args.pattern)
+    if not args.zettel_paths:
+        if args.pattern is None:
+            args.pattern = ['*.md']
+        patterns = '|'.join(args.pattern)
 
-    zettels = parse_zettels(zettel_paths)
+        args.zettel_paths = list_zettels(args.notes_dir, pattern=patterns)
+    return args
+
+
+def main(args=None):
+    import sys
+    args = parse_args(args)
+
+    zettels = parse_zettels(args.zettel_paths)
 
     # Fail in case we didn't find a zettel
     if not zettels:


### PR DESCRIPTION
This fixes a bug where a the `--pattern` was actually ignored, but also allows the user to specify multiple patterns. The files that match each pattern will be combined together.

Fixes #5. Overrides #3.