### PR TITLE
ENH: Add option to use Graphviz to draw the network

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ Then install zkviz with:
 pip install zkviz
 ```
 
+If [Graphviz](https://graphviz.org/download/) is installed on your computer,
+zkviz can use it to draw the network. It is not a Python package so it needs to
+be installed independently. If you're on a Mac and have
+[Homebrew](https://brew.sh) installed, you can install Graphviz from a Terminal
+with:
+
+```sh
+brew install graphviz
+```
+
 ## Usage
 
 To execute zkviz from the Terminal, you either need to add the zkviz
@@ -56,6 +66,12 @@ You can also pass a list of files to zkviz:
 
 ```sh
 ~/envs/zkviz/bin/zkviz "~/Notes/201906021303 the state of affairs.md" "~/Notes/201901021232 Journey to the center of the earth.md"
+```
+
+To use Graphviz to generate the visualization, add the `--use-graphviz` option:
+
+```sh
+~/envs/zkviz/bin/zkviz --notes-dir ~/Notes --use-graphviz
 ```
 
 ## Using zkviz with Keyboard Maestro

--- a/keyboard-maestro/Generate network visualization of notes selected in The Archive using zkviz.kmmacros
+++ b/keyboard-maestro/Generate network visualization of notes selected in The Archive using zkviz.kmmacros
@@ -221,12 +221,12 @@ import subprocess
 # Get path to the zkviz executable
 zkviz = os.environ['KMVAR_ZKVIZ_PATH']
 
-# Check if `/usr/local/bin` is in the PATH, which is need for Graphviz.
-# If not, append it
+# Check if `/usr/local/bin` is in the PATH, which is needed for Graphviz.
+# If not, append it.
 if '/usr/loca/bin/' not in os.environ['PATH']:
     os.environ['PATH'] += ':/usr/local/bin'
 
-# Get path to the zkviz executable
+# Use graphviz or not
 use_graphviz = int(os.environ['KMVAR_ZKVIZ_USE_GRAPHVIZ'])
 
 # Get the list of paths using environment variables.
@@ -236,7 +236,7 @@ filenames = os.environ['KMVAR_ZKVIZ_ZETTEL_FILENAMES'].strip().splitlines()
 archive_path = os.path.expanduser(os.environ['KMVAR_ZKVIZ_ARCHIVE_PATH'])
 output_filename = os.path.join(archive_path, 'zettel-network.html')
 
-# Build the arguments to 
+# Build the arguments to execute
 args = [zkviz, '--output', output_filename] + filenames
 if use_graphviz:
 	args.insert(1, '--use-graphviz')
@@ -260,7 +260,7 @@ except subprocess.CalledProcessError as exc:
 				<key>CreationDate</key>
 				<real>582430104.35251606</real>
 				<key>ModificationDate</key>
-				<real>586837534.73863602</real>
+				<real>586837783.08286202</real>
 				<key>Name</key>
 				<string>Generate network visualization of notes selected in The Archive using zkviz</string>
 				<key>Triggers</key>

--- a/keyboard-maestro/Generate network visualization of notes selected in The Archive using zkviz.kmmacros
+++ b/keyboard-maestro/Generate network visualization of notes selected in The Archive using zkviz.kmmacros
@@ -18,10 +18,10 @@
 						<key>StyledText</key>
 						<data>
 						cnRmZAAAAAADAAAAAgAAAAcAAABU
-						WFQucnRmAQAAAC6sAwAAKwAAAAEA
-						AACkAwAAe1xydGYxXGFuc2lcYW5z
+						WFQucnRmAQAAAC4kBAAAKwAAAAEA
+						AAAcBAAAe1xydGYxXGFuc2lcYW5z
 						aWNwZzEyNTJcY29jb2FydGYxNjcx
-						XGNvY29hc3VicnRmNTAwCntcZm9u
+						XGNvY29hc3VicnRmNjAwCntcZm9u
 						dHRibFxmMFxmbmlsXGZjaGFyc2V0
 						MCBIZWx2ZXRpY2FOZXVlO30Ke1xj
 						b2xvcnRibDtccmVkMjU1XGdyZWVu
@@ -43,29 +43,35 @@
 						bGVjdGUgaW4gVGhlIEFyY2hpdmUg
 						YXBwIFsyXS5cClwKRm9yIHRoaXMg
 						bWFjcm8gdG8gd29yayBwcm9wZXJs
-						eSwgcGxlYXNlIHNldCB0aGUgbmV4
-						dCB0d28gdmFyaWFibGVzOlwKXAot
-						IFpLVklaX0FSQ0hJVkVfUEFUSCBp
-						cyB0aGUgcGF0aCB0byB3aGVyZSB5
-						b3VyIGFyY2hpdmUgbm90ZXMgYXJl
-						IHN0b3JlLiBGb3IgZXhhbXBsZSwg
-						fi9Ecm9wYm94L05vdGVzXAotIFpL
-						VklaX1BBVEggaXMgdGhlIGFic29s
-						dXRlIHBhdGggdG8gdGhlIHprdml6
-						IGV4ZWN1dGFibGUuIFBsZWFzZSBz
-						ZWUgWzFdIGZvciBpbnN0cnVjdGlv
-						bnMgb2YgaG93IHRvIGluc3RhbGwg
-						aXQuIFRoZSBwYXRoIGJlbG93IHVz
-						ZXMgdGhlIG9uZSB5b3UnZCBoYXZl
-						IGlmIHlvdSBmb2xsb3dlZCB0aGUg
-						aW5zdHJ1Y3Rpb25zIGRpcmVjdGx5
-						LlwKXApbMV06IGh0dHBzOi8vZ2l0
-						aHViLmNvbS9aZXR0ZWxrYXN0ZW4t
-						TWV0aG9kL3prdml6XApbMl06IGh0
-						dHBzOi8vemV0dGVsa2FzdGVuLmRl
-						L3RoZS1hcmNoaXZlL30BAAAAIwAA
-						AAEAAAAHAAAAVFhULnJ0ZhAAAADe
-						TQhdtgEAAAAAAAAAAAAA
+						eSwgcGxlYXNlIHNldCB0aGVzZSB2
+						YXJpYWJsZXM6XApcCi0gWktWSVpf
+						QVJDSElWRV9QQVRIIGlzIHRoZSBw
+						YXRoIHRvIHdoZXJlIHlvdXIgYXJj
+						aGl2ZSBub3RlcyBhcmUgc3RvcmUu
+						IEZvciBleGFtcGxlLCB+L0Ryb3Bi
+						b3gvTm90ZXNcCi0gWktWSVpfUEFU
+						SCBpcyB0aGUgYWJzb2x1dGUgcGF0
+						aCB0byB0aGUgemt2aXogZXhlY3V0
+						YWJsZS4gUGxlYXNlIHNlZSBbMV0g
+						Zm9yIGluc3RydWN0aW9ucyBvZiBo
+						b3cgdG8gaW5zdGFsbCBpdC4gVGhl
+						IHBhdGggYmVsb3cgdXNlcyB0aGUg
+						b25lIHlvdSdkIGhhdmUgaWYgeW91
+						IGZvbGxvd2VkIHRoZSBpbnN0cnVj
+						dGlvbnMgZGlyZWN0bHkuXAotIFpL
+						VklaX1VTRV9HUkFQSFZJWiBzZXQg
+						dG8gMSBpZiB5b3Ugd2FudCB0byB1
+						c2UgR3JhcGh2aXogdG8gZ2VuZXJh
+						dGUgdGhlIHZpc3VhbGl6YXRpb24u
+						IE9yIHVzZSAwIGlmIHlvdSB3YW50
+						IHRvIHVzZSBQbG90bHlcClwKXApb
+						MV06IGh0dHBzOi8vZ2l0aHViLmNv
+						bS9aZXR0ZWxrYXN0ZW4tTWV0aG9k
+						L3prdml6XApbMl06IGh0dHBzOi8v
+						emV0dGVsa2FzdGVuLmRlL3RoZS1h
+						cmNoaXZlL30BAAAAIwAAAAEAAAAH
+						AAAAVFhULnJ0ZhAAAAA/NkpdtgEA
+						AAAAAAAAAAAA
 						</data>
 						<key>Title</key>
 						<string>README</string>
@@ -89,6 +95,16 @@
 						<string>~/envs/zkviz/bin/zkviz</string>
 						<key>Variable</key>
 						<string>ZKVIZ_PATH</string>
+					</dict>
+					<dict>
+						<key>ActionName</key>
+						<string>Choose whether to use Graphviz or not to render the visualization [0 or 1]</string>
+						<key>MacroActionType</key>
+						<string>SetVariableToText</string>
+						<key>Text</key>
+						<string>0</string>
+						<key>Variable</key>
+						<string>ZKVIZ_USE_GRAPHVIZ</string>
 					</dict>
 					<dict>
 						<key>ActionName</key>
@@ -189,8 +205,6 @@
 						<string>Window</string>
 						<key>IncludeStdErr</key>
 						<true/>
-						<key>IsDisclosed</key>
-						<false/>
 						<key>MacroActionType</key>
 						<string>ExecuteShellScript</string>
 						<key>Path</key>
@@ -207,6 +221,14 @@ import subprocess
 # Get path to the zkviz executable
 zkviz = os.environ['KMVAR_ZKVIZ_PATH']
 
+# Check if `/usr/local/bin` is in the PATH, which is need for Graphviz.
+# If not, append it
+if '/usr/loca/bin/' not in os.environ['PATH']:
+    os.environ['PATH'] += ':/usr/local/bin'
+
+# Get path to the zkviz executable
+use_graphviz = int(os.environ['KMVAR_ZKVIZ_USE_GRAPHVIZ'])
+
 # Get the list of paths using environment variables.
 filenames = os.environ['KMVAR_ZKVIZ_ZETTEL_FILENAMES'].strip().splitlines()
 
@@ -216,6 +238,8 @@ output_filename = os.path.join(archive_path, 'zettel-network.html')
 
 # Build the arguments to 
 args = [zkviz, '--output', output_filename] + filenames
+if use_graphviz:
+	args.insert(1, '--use-graphviz')
 
 # Capture error messages and display them if something happens. Otherwise,
 # this should print any output.
@@ -236,7 +260,7 @@ except subprocess.CalledProcessError as exc:
 				<key>CreationDate</key>
 				<real>582430104.35251606</real>
 				<key>ModificationDate</key>
-				<real>582518133.38314497</real>
+				<real>586837534.73863602</real>
 				<key>Name</key>
 				<string>Generate network visualization of notes selected in The Archive using zkviz</string>
 				<key>Triggers</key>

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setuptools.setup(
     url="https://github.com/Zettelkasten-Method/zkviz",
     packages=setuptools.find_packages(),
     install_requires=[
+        'graphviz',
         'plotly',
         'numpy',
         'scipy',

--- a/zkviz/graphviz.py
+++ b/zkviz/graphviz.py
@@ -1,0 +1,87 @@
+from textwrap import fill
+
+from graphviz import Digraph
+
+
+class NetworkGraphviz:
+
+    def __init__(self, name='Zettelkasten', engine='sfdp', shape='record'):
+        """
+        Build network to visualize with Graphviz.
+
+        Parameters
+        ----------
+        name : str (optional)
+            Name of the network. Default is "Zettelkasten".
+        engine : str
+            Layout engine used by Graphviz. The default is 'sfdp', which is a
+            good default. See the graphviz documentation for alternatives.
+        shape : str {record, plaintext}
+            The shape, or style, of each node. The default is "record".
+        """
+        self.name = name
+        self.engine = engine
+        self.graph = Digraph(comment=self.name, engine=self.engine)
+        self.shape = shape
+
+    def wrap_title(self, text, width=30):
+        """
+        Wrap the title to be a certain width.
+
+        Parameters
+        ----------
+        text : str
+            The text to wrap.
+        width : int
+            The text width, in characters.
+
+        """
+        return fill(text, width)
+
+    def add_node(self, node_id, title):
+        """
+        Add a node to the network.
+
+        Parameters
+        ----------
+        node_id : str, or int
+            A  unique identifier for the node, typically the zettel ID.
+        title : str
+            The text label for each node, typically the zettel title.
+
+        """
+        if self.shape == 'plaintext':
+            label = self.wrap_title("{} {}".format(node_id, title)).strip()
+        elif self.shape == 'record':
+            # Wrap in {} so the elements are stacked vertically
+            label = "{" + '|'.join([node_id, self.wrap_title(title)]) + "}"
+
+        self.graph.node(node_id, label, shape=self.shape)
+
+    def add_edge(self, source, target):
+        """
+        Add a node (a zettel) to the network.
+
+        Parameters
+        ----------
+        source : str or int
+            The ID of the source zettel.
+        target : str or int
+            The ID of the target (cited) zettel.
+
+        """
+        self.graph.edge(source, target)
+
+    def render(self, output, view=True):
+        """
+        Render the network to disk.
+
+        Parameters
+        ----------
+        output : str
+            Name of the output file.
+        view : bool
+            Show the network using the default PDF viewer. Default is True.
+
+        """
+        self.graph.render(output, view=view)

--- a/zkviz/plotly.py
+++ b/zkviz/plotly.py
@@ -1,0 +1,155 @@
+import networkx as nx
+import plotly.graph_objs as go
+
+
+class NetworkPlotly:
+
+    def __init__(self, name='Zettelkasten'):
+        """
+        Build network to visualize with Plotly
+
+        Parameters
+        ----------
+        name : str
+            The network name.
+        """
+        self.graph = nx.Graph()
+
+    def add_node(self, node_id, title):
+        """
+        Add a node to the network.
+
+        Parameters
+        ----------
+        node_id : str, or int
+            A  unique identifier for the node, typically the zettel ID.
+        title : str
+            The text label for each node, typically the zettel title.
+
+        """
+        self.graph.add_node(node_id, title=title)
+
+    def add_edge(self, source, target):
+        """
+        Add a node (a zettel) to the network.
+
+        Parameters
+        ----------
+        source : str or int
+            The ID of the source zettel.
+        target : str or int
+            The ID of the target (cited) zettel.
+
+        """
+        self.graph.add_edge(source, target)
+
+    def build_plotly_figure(self, pos=None):
+        """
+        Creates a Plot.ly Figure that can be view online or offline.
+
+        Parameters
+        ----------
+        graph : nx.Graph
+            The network of zettels to visualize
+        pos : dict
+            Dictionay of zettel_id : (x, y) coordinates where to draw nodes. If
+            None, the Kamada Kawai layout will be used.
+
+        Returns
+        -------
+        fig : plotly Figure
+
+        """
+
+        if pos is None:
+            # The kamada kawai layout produces a really nice graph but it's
+            # a O(N^2) algorithm. It seems only reasonable to draw the graph
+            # with fewer than ~1000 nodes.
+            if len(self.graph) < 1000:
+                pos = nx.layout.kamada_kawai_layout(self.graph)
+            else:
+                pos = nx.layout.random_layout(self.graph)
+
+        # Create scatter plot of the position of all notes
+        node_trace = go.Scatter(
+            x=[],
+            y=[],
+            text=[],
+            mode='markers',
+            hoverinfo='text',
+            marker=dict(
+                showscale=True,
+                # colorscale options
+                #'Greys' | 'YlGnBu' | 'Greens' | 'YlOrRd' | 'Bluered' | 'RdBu' |
+                #'Reds' | 'Blues' | 'Picnic' | 'Rainbow' | 'Portland' | 'Jet' |
+                #'Hot' | 'Blackbody' | 'Earth' | 'Electric' | 'Viridis' |
+                colorscale='YlGnBu',
+                reversescale=True,
+                color=[],
+                size=10,
+                colorbar=dict(
+                    thickness=15,
+                    title='Centrality',
+                    xanchor='left',
+                    titleside='right'
+                ),
+                line=dict(width=2)))
+
+        for node in self.graph.nodes():
+            x, y = pos[node]
+            text = '<br>'.join([node, self.graph.node[node].get('title', '')])
+            node_trace['x'] += tuple([x])
+            node_trace['y'] += tuple([y])
+            node_trace['text'] += tuple([text])
+
+        # Color nodes based on the centrality
+        for node, centrality in nx.degree_centrality(self.graph).items():
+            node_trace['marker']['color']+=tuple([centrality])
+
+        # Draw the edges as annotations because it's only sane way to draw arrows.
+        edges = []
+        for from_node, to_node in self.graph.edges():
+            edges.append(
+                dict(
+                    # Tail coordinates
+                    ax=pos[from_node][0], ay=pos[from_node][1], axref='x', ayref='y',
+                    # Head coordinates
+                    x=pos[to_node][0], y=pos[to_node][1], xref='x', yref='y',
+                    # Aesthetics
+                    arrowwidth=2, arrowcolor='#666', arrowhead=2,
+                    # Have the head stop short 5 px for the center point,
+                    # i.e., depends on the node marker size.
+                    standoff=5,
+                    )
+                )
+
+        fig = go.Figure(
+            data=[node_trace],
+            layout=go.Layout(
+                showlegend=False,
+                hovermode='closest',
+                margin=dict(b=20, l=5, r=5, t=40),
+                annotations=edges,
+                xaxis=dict(showgrid=False, zeroline=False, showticklabels=False),
+                yaxis=dict(showgrid=False, zeroline=False, showticklabels=False),
+            )
+        )
+        return fig
+
+    def render(self, output, view=True):
+        """
+        Render the network to disk.
+
+        Parameters
+        ----------
+        output : str
+            Name of the output file.
+        view : bool
+            Open the rendered network using the default browser. Default is
+            True.
+
+        """
+        fig = self.build_plotly_figure()
+        if not output.endswith('.html'):
+            output += '.html'
+        fig.write_html(output, auto_open=view)

--- a/zkviz/zkviz.py
+++ b/zkviz/zkviz.py
@@ -10,10 +10,9 @@ links have the form [[YYYYMMDDHHMM]]
 import glob
 import os.path
 import re
+from textwrap import fill
 
-import networkx as nx
-import plotly
-import plotly.graph_objs as go
+
 
 
 PAT_ZK_ID = re.compile(r'^(?P<id>\d+)\s(.*)')
@@ -42,7 +41,7 @@ def parse_zettels(filepaths):
     return documents
 
 
-def create_graph(zettels):
+def create_graph(zettels, graph):
     """
     Create of graph of the zettels linking to each other.
 
@@ -56,13 +55,11 @@ def create_graph(zettels):
 
     """
 
-    g = nx.Graph()
-
     for doc in zettels:
-        g.add_node(doc['id'], title=doc['title'])
+        graph.add_node(doc['id'], title=doc['title'])
         for link in doc['links']:
-            g.add_edge(doc['id'], link)
-    return g
+            graph.add_edge(doc['id'], link)
+    return graph
 
 
 def list_zettels(notes_dir, pattern='*.md'):
@@ -86,111 +83,18 @@ def list_zettels(notes_dir, pattern='*.md'):
     return sorted(filepaths)
 
 
-def create_plotly_plot(graph, pos=None):
-    """
-    Creates a Plot.ly Figure that can be view online of offline.
-
-    Parameters
-    ----------
-    graph : nx.Graph
-        The network of zettels to visualize
-    pos : dict
-        Dictionay of zettel_id : (x, y) coordinates where to draw nodes. If
-        None, the Kamada Kawai layout will be used.
-
-    Returns
-    -------
-    fig : plotly Figure
-
-    """
-
-    if pos is None:
-        # The kamada kawai layout produces a really nice graph but it's
-        # a O(N^2) algorithm. It seems only reasonable to draw the graph
-        # with fewer than ~1000 nodes.
-        if len(graph) < 1000:
-            pos = nx.layout.kamada_kawai_layout(graph)
-        else:
-            pos = nx.layout.random_layout(graph)
-
-    # Create scatter plot of the position of all notes
-    node_trace = go.Scatter(
-        x=[],
-        y=[],
-        text=[],
-        mode='markers',
-        hoverinfo='text',
-        marker=dict(
-            showscale=True,
-            # colorscale options
-            #'Greys' | 'YlGnBu' | 'Greens' | 'YlOrRd' | 'Bluered' | 'RdBu' |
-            #'Reds' | 'Blues' | 'Picnic' | 'Rainbow' | 'Portland' | 'Jet' |
-            #'Hot' | 'Blackbody' | 'Earth' | 'Electric' | 'Viridis' |
-            colorscale='YlGnBu',
-            reversescale=True,
-            color=[],
-            size=10,
-            colorbar=dict(
-                thickness=15,
-                title='Centrality',
-                xanchor='left',
-                titleside='right'
-            ),
-            line=dict(width=2)))
-
-    for node in graph.nodes():
-        x, y = pos[node]
-        text = '<br>'.join([node, graph.node[node].get('title', '')])
-        node_trace['x'] += tuple([x])
-        node_trace['y'] += tuple([y])
-        node_trace['text'] += tuple([text])
-
-    # Color nodes based on the centrality
-    for node, centrality in nx.degree_centrality(graph).items():
-        node_trace['marker']['color']+=tuple([centrality])
-
-    # Draw the edges as annotations because it's only sane way to draw arrows.
-    edges = []
-    for from_node, to_node in graph.edges():
-        edges.append(
-            dict(
-                # Tail coordinates
-                ax=pos[from_node][0], ay=pos[from_node][1], axref='x', ayref='y',
-                # Head coordinates
-                x=pos[to_node][0], y=pos[to_node][1], xref='x', yref='y',
-                # Aesthetics
-                arrowwidth=2, arrowcolor='#666', arrowhead=2,
-                # Have the head stop short 5 px for the center point,
-                # i.e., depends on the node marker size.
-                standoff=5,
-                )
-            )
-
-    fig = go.Figure(
-        data=[node_trace],
-        layout=go.Layout(
-            showlegend=False,
-            hovermode='closest',
-            margin=dict(b=20, l=5, r=5, t=40),
-            annotations=edges,
-            xaxis=dict(showgrid=False, zeroline=False, showticklabels=False),
-            yaxis=dict(showgrid=False, zeroline=False, showticklabels=False),
-        )
-    )
-
-    return fig
-
-
 def parse_args(args=None):
     from argparse import ArgumentParser
     parser = ArgumentParser(description=__doc__)
     parser.add_argument('--notes-dir', default='.',
                         help='path to folder containin notes. [.]')
-    parser.add_argument('--output', default='zettel-network.html',
-                        help='name of output file. [zettel-network.html]')
+    parser.add_argument('--output', default='zettel-network',
+                        help='name of output file. [zettel-network]')
     parser.add_argument('--pattern', action='append',
             help=('pattern to match notes. You can repeat this argument to'
             ' match multiple file types. [*.md]'))
+    parser.add_argument('--use-graphviz', action='store_true', default=False,
+            help='Use Graphviz instead of plotly to render the network.')
     parser.add_argument('zettel_paths', nargs='*', help='zettel file paths.')
     args = parser.parse_args(args=args)
 
@@ -206,21 +110,40 @@ def parse_args(args=None):
 
 
 def main(args=None):
-    import sys
     args = parse_args(args)
 
     zettels = parse_zettels(args.zettel_paths)
 
     # Fail in case we didn't find a zettel
     if not zettels:
-        sys.exit("I'm sorry, I couldn't find any files.")
+        raise FileNotFoundError("I'm sorry, I couldn't find any files.")
 
-    graph = create_graph(zettels)
-    fig = create_plotly_plot(graph)
+    if args.use_graphviz:
+        from zkviz.graphviz import NetworkGraphviz
+        import graphviz
+        try:
+            graphviz.version()
+        except graphviz.ExecutableNotFound:
+            raise FileNotFoundError(fill(
+                "The Graphviz application must be installed for the"
+                " --use-graphviz option to work. Please see"
+                " https://graphviz.org/download/ for installation"
+                " instructions."
+           ))
+        graph = NetworkGraphviz()
+    else:
+        from zkviz.plotly import NetworkPlotly
+        graph = NetworkPlotly()
 
-    plotly.offline.plot(fig, filename=args.output)
+    graph = create_graph(zettels, graph)
+    graph.render(args.output)
 
 
 if __name__ == "__main__":
     import sys
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except FileNotFoundError as e:
+        # Failed either because it didn't find any files or because Graphviz
+        # wasn't installed
+        sys.exit(e)


### PR DESCRIPTION
Adds a `--use-graphviz` flag to create and render the network using Graphviz instead of plotly. Requires that the Graphviz application be installed.

On Mac, Graphviz can be installed from homebrew with:

```
brew install graphviz
```