### PR TITLE
fix plot.ly

### DIFF
--- a/zkviz/plotly.py
+++ b/zkviz/plotly.py
@@ -95,7 +95,7 @@ class NetworkPlotly:
 
         for node in self.graph.nodes():
             x, y = pos[node]
-            text = "<br>".join([node, self.graph.node[node].get("title", "")])
+            text = "<br>".join([node, self.graph.nodes[node].get("title", "")])
             node_trace["x"] += tuple([x])
             node_trace["y"] += tuple([y])
             node_trace["text"] += tuple([text])


### PR DESCRIPTION
solve the following bug:

Traceback (most recent call last):
File "/Users/tdiaz/envs/zkviz/bin/zkviz", line 11, in
load_entry_point('zkviz==1.3.0', 'console_scripts', 'zkviz')()
File "/Users/tdiaz/envs/zkviz/lib/python3.7/site-packages/zkviz/zkviz.py", line 197, in main
graph.render(args.output)
File "/Users/tdiaz/envs/zkviz/lib/python3.7/site-packages/zkviz/plotly.py", line 158, in render
fig = self.build_plotly_figure()
File "/Users/tdiaz/envs/zkviz/lib/python3.7/site-packages/zkviz/plotly.py", line 98, in build_plotly_figure
text = "
".join([node, self.graph.node[node].get("title", "")])
AttributeError: 'Graph' object has no attribute 'node'